### PR TITLE
Bump pluginUntilBuild to 202.* in template cleanup

### DIFF
--- a/.github/template-cleanup/gradle.properties
+++ b/.github/template-cleanup/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = %GROUP%
 pluginName = %NAME%
 pluginVersion = 0.0.1
 pluginSinceBuild = 193
-pluginUntilBuild = 201.*
+pluginUntilBuild = 202.*
 
 platformType = IC
 platformVersion = 2019.3


### PR DESCRIPTION
Using template overwrites `gradle.properties`, cleanup makes plugin unusable in current platform