### PR TITLE
chore: cache gradle wrapper directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,11 @@ jobs:
 
       # Cache Gradle dependencies
       - name: Setup Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle-
 
@@ -94,9 +96,11 @@ jobs:
 
       # Cache Gradle dependencies
       - name: Setup Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: ~/.gradle/caches
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle-
 


### PR DESCRIPTION
This PR adds caching Gradle wrapper directory in GitHub Actions.

Updating `actions/cache` to v2 allows to cache multiple paths. So now we can cache Gradle wrapper directory and avoid downloading it every time.
Official Gradle example: https://github.com/actions/cache/blob/main/examples.md#java---gradle