### PR TITLE
Use `main` branch for changelog commit push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,4 +56,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
+          branch: main
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changelog commits should be pushed to the `main` branch, the Github action defaults to `master` still.

Similar to #31 -- sorry I missed this case!