### PR TITLE
Update pluginName_

### DIFF
--- a/.github/template-cleanup/gradle.properties
+++ b/.github/template-cleanup/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = %GROUP%
-pluginName = %NAME%
+pluginName_ = %NAME%
 pluginVersion = 0.0.1
 pluginSinceBuild = 193
 pluginUntilBuild = 202.*


### PR DESCRIPTION
Template cleanup changes `pluginName_` to `pluginName`, so it causes errors on building