### PR TITLE
Switch back to using Github containers to fix changelog commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,13 @@ jobs:
     name: Test
     needs: gradleValidation
     runs-on: ubuntu-latest
-    container: gradle:jdk8
     steps:
+
+      # Setup Java 1.8 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
       # Check out current repository
       - name: Fetch Sources
@@ -71,13 +76,18 @@ jobs:
     name: Build
     needs: test
     runs-on: ubuntu-latest
-    container: gradle:jdk8
     outputs:
       name: ${{ steps.properties.outputs.name }}
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}
       artifact: ${{ steps.properties.outputs.artifact }}
     steps:
+      
+      # Setup Java 1.8 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
       # Check out current repository
       - name: Fetch Sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,13 @@ jobs:
   release:
     name: Publish Plugin
     runs-on: ubuntu-latest
-    container: gradle:jdk8
     steps:
+
+      # Setup Java 1.8 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
       # Check out current repository
       - name: Fetch Sources
@@ -32,8 +37,13 @@ jobs:
     name: Update Changelog
     needs: release
     runs-on: ubuntu-latest
-    container: gradle:jdk8
     steps:
+
+      # Setup Java 1.8 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
       # Check out current repository
       - name: Fetch Sources


### PR DESCRIPTION
The docker container `gradle:jdk8` uses Git 2.17 which causes the checkout action to clone the repo via HTTP instead of creating a local git repo. This breaks the changelog auto commit, since there's no local repo to commit to.

Example of this failure: https://github.com/nbadal/ktlint-intellij-plugin/runs/1119530857
This can be verified as well by running the following, locally:
`docker run --rm gradle:jdk8 git --version`

This change switches back to the Github-hosted action containers, which are going to be more up-to-date anyway than any other custom container, at the expense of adding back the Java setup action.