### PR TITLE
Fix ProjectManagerListener scope

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,8 +12,8 @@
         <projectService serviceImplementation="org.jetbrains.plugins.template.services.MyProjectService"/>
     </extensions>
 
-    <projectListeners>
+    <applicationListeners>
         <listener class="org.jetbrains.plugins.template.listeners.MyProjectManagerListener"
                   topic="com.intellij.openapi.project.ProjectManagerListener"/>
-    </projectListeners>
+    </applicationListeners>
 </idea-plugin>


### PR DESCRIPTION
Hi! 

I'm creating a plugin and started from this template, but had trouble showing a simple message. The logs indicated my plugin was loading correctly but on the UI nothing happened. After spending some time trying various things, I took a look at the code samples and didn't find any `<projectListeners>` like the one in the template. I only found `<applicationListeners>`, so I tried replacing `<projectListeners>` with it and everything worked.

Apparently, listeners for topic `com.intellij.openapi.project.ProjectManagerListener` don't work inside `<projectListeners>`, only `<applicationListeners>`.