### PR TITLE
Upgrade to Java 11 for 2020.3 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources
@@ -83,11 +83,11 @@ jobs:
       artifact: ${{ steps.properties.outputs.artifact }}
     steps:
       
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources
@@ -39,11 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Check out current repository
       - name: Fetch Sources

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,19 +72,19 @@ detekt {
 }
 
 tasks {
-    // Set the compatibility versions to 1.8
+    // Set the compatibility versions to 11
     withType<JavaCompile> {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+        sourceCompatibility = "11"
+        targetCompatibility = "11"
     }
     listOf("compileKotlin", "compileTestKotlin").forEach {
         getByName<KotlinCompile>(it) {
-            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.jvmTarget = "11"
         }
     }
 
     withType<Detekt> {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     patchPluginXml {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@
 pluginGroup = org.jetbrains.plugins.template
 pluginName_ = IntelliJ Platform Plugin Template
 pluginVersion = 0.3.4
-pluginSinceBuild = 193
-pluginUntilBuild = 202.*
+pluginSinceBuild = 203
+pluginUntilBuild = 203.*
 
 platformType = IC
-platformVersion = 2019.3
+platformVersion = 2020.3
 platformDownloadSources = true
 
 # Opt-out flag for bundling Kotlin standard library.


### PR DESCRIPTION
Just had this problem with one of my plugins, when trying to do some 2020.3 related stuff. 

So think we should consider if we want to change this repo to 2020.3 with java 11?