### PR TITLE
Add missing gradle.properties values to cleanup

### DIFF
--- a/.github/template-cleanup/gradle.properties
+++ b/.github/template-cleanup/gradle.properties
@@ -10,3 +10,10 @@ pluginUntilBuild = 202.*
 platformType = IC
 platformVersion = 2019.3
 platformDownloadSources = true
+# Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
+# Example: platformPlugins = com.intellij.java,com.jetbrains.php:203.4449.22
+platformPlugins =
+
+# Opt-out flag for bundling Kotlin standard library.
+# See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
+kotlin.stdlib.default.dependency = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # IntelliJ Platform Plugin Template Changelog
 
 ## [Unreleased]
+### Added
+- Missing properties in the `gradle.properties` template file
+
 ### Changed
 - Dependencies - upgrade `org.jetbrains.changelog` to 0.6.2
 


### PR DESCRIPTION
After the template cleanup has ran, the following properties are not there anymore.

So I just added them to the cleanup gradle.properties, so user's can see that this is some options which is supported.