### PR TITLE
Update detekt config to be in line with IJ settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 ### Changed
 - Switch Gradle Wrapper to `-all` to improve the IntelliSense
+- Update detekt config to be in line with IJ settings
 
 ## [0.5.1]
 ### Added

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -3,4 +3,6 @@
 
 formatting:
   Indentation:
-    active: true
+    continuationIndentSize: 8
+  ParameterListWrapping:
+    indentSize: 8


### PR DESCRIPTION
The default detekt configuration for continuation indent is 4, what conflicts with the default configuration in IJ. I suggest updating detekt configuration to have the same continuation indent as in IJ.
`ParameterListWrapping` option is updated as well because it's covered by "continuation indent" option in IJ.

Example of code with continuation indent:
![image](https://user-images.githubusercontent.com/4203721/96369655-fda7d000-1163-11eb-8d33-affcd77bc0eb.png)

Example of `ParameterListWrapping` code:
![image](https://user-images.githubusercontent.com/4203721/96369623-cfc28b80-1163-11eb-82a3-2d910352d712.png)

![image](https://user-images.githubusercontent.com/4203721/96369568-87a36900-1163-11eb-86b1-65faf30e3646.png)
