### PR TITLE
Use Kotlin extension function to retrieve service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Dependencies - upgrade `org.jetbrains.intellij` to `0.6.1`
 - GitHub Actions - `gradleValidation` update to `gradle/wrapper-validation-action@v1.0.3`
 - GitHub Actions - `releaseDraft` update to `actions/download-artifact@v2`
+- Use [Kotlin extension function](https://jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_services.html?search=servic#retrieving-a-service) to retrieve the `MyProjectService` in the `MyProjectManagerListener`
 
 ### Removed
 - Remove Third-party IntelliJ Plugin Verifier GitHub Action

--- a/src/main/kotlin/org/jetbrains/plugins/template/listeners/MyProjectManagerListener.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/listeners/MyProjectManagerListener.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.plugins.template.listeners
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
 import org.jetbrains.plugins.template.services.MyProjectService
@@ -7,6 +8,6 @@ import org.jetbrains.plugins.template.services.MyProjectService
 internal class MyProjectManagerListener : ProjectManagerListener {
 
     override fun projectOpened(project: Project) {
-        project.getService(MyProjectService::class.java)
+        project.service<MyProjectService>()
     }
 }


### PR DESCRIPTION
As show in the [documentation](https://jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_services.html?search=servic#retrieving-a-service), a convenience method is available to retrieve services.

This PR changes the "Java-style" service retrieval in `MyProjectManagerListener` to the Kotlin extension function.
I think it is a nice way to make developers aware of its existence (I was very happy to refactor to this approach when I found out the function existed 😉 ).