### PR TITLE
Adding log_file in the predefined run configuration files

### DIFF
--- a/.run/Run IDE with Plugin.run.xml
+++ b/.run/Run IDE with Plugin.run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Plugin Tests.run.xml
+++ b/.run/Run Plugin Tests.run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/.run/Run Plugin Verification.run.xml
+++ b/.run/Run Plugin Verification.run.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Verifications" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />


### PR DESCRIPTION
Added to the 3 predefined run configuration files. 
Tested it by creating from the template a new repository and running all the 3 run configuraitons. 
In the runIde and in the check tasks I saw there were some printing in the idea.log while in tests there were not so I am not sure about the need in it. 
