### PR TITLE
Fix `MyBundle.messagePointer` to return `Supplier<@Nls String>` instead of `String`

### DIFF
--- a/src/main/kotlin/org/jetbrains/plugins/template/MyBundle.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/template/MyBundle.kt
@@ -11,11 +11,11 @@ object MyBundle : AbstractBundle(BUNDLE) {
 
     @Suppress("SpreadOperator")
     @JvmStatic
-    fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) = getMessage(key, *params)
+    fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) =
+        getMessage(key, *params)
 
     @Suppress("SpreadOperator")
     @JvmStatic
-    fun messagePointer(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) = run {
-        message(key, *params)
-    }
+    fun messagePointer(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any) =
+        getLazyMessage(key, *params)
 }


### PR DESCRIPTION
I believe `run { message() }` was a typo there - it would just return a string, similar to `message`.

Returning `Supplier` is not idiomatic Kotlin, but it:
- Allows annotating type parameter with `@Nls`
- Is similar to most in-tree IJ bundles