### PR TITLE
Use the correct property in the "Upload artifact" step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: plugin-artifact
-          path: ./build/distributions/${{ needs.build.outputs.artifact }}
+          path: ./build/distributions/${{ steps.properties.outputs.artifact }}
 
   # Verify built plugin using IntelliJ Plugin Verifier tool
   # Requires build job to be passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 - Upgrade Gradle Wrapper to `6.8`
 
 ### Fixed
-- Template Cleanup: escape GitHub username to avoid incorrect characters in class package name
-- Template Cleanup: run `ktlintFormat` task to fix imports order
+- Template Cleanup: Escape GitHub username to avoid incorrect characters in class package name
+- Template Cleanup: Run `ktlintFormat` task to fix imports order
+- GitHub Actions: Use the correct property in the "Upload artifact" step
 
 ## [0.8.0]
 ### Added


### PR DESCRIPTION
The `needs.build` accessor is only available in downstream jobs that depend on the `build` job.

For steps that are part of the same job, the `needs.build.outputs.artifact` property is empty.