### PR TITLE
Fixed plugin version property key

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = properties("pluginGroup")
-version = properties("projectVersion")
+version = properties("pluginVersion")
 
 // Configure project's dependencies
 repositories {


### PR DESCRIPTION
It fixes **null** value instead of actual plugin version.
You could find the problem in draft release name.