### PR TITLE
Fix README.md resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,7 @@ tasks {
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription(
             closure {
-                File("./README.md").readText().lines().run {
+                File(projectDir, "README.md").readText().lines().run {
                     val start = "<!-- Plugin description -->"
                     val end = "<!-- Plugin description end -->"
 


### PR DESCRIPTION
In some build environments projectDir may differ from current working directory. In such environments build before this change would fail with IOException.