### PR TITLE
Update dependabot configuration to also track github actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,13 @@
 
 version: 2
 updates:
+  # Maintain dependencies for Gradle dependencies
   - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 ### Added
 - `properties` shorthand function for accessing `gradle.properties` in a cleaner way
+- Dependabot check for GitHub Actions used in [workflow files](.github/workflows)
 
 ## [0.8.3]
 ### Changed


### PR DESCRIPTION
https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates