### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+
+* text  eol=lf
+
+# These are explicitly windows files and should use crlf
+*.bat   text eol=crlf
+
+# These files are text and should be normalized (Convert crlf => lf)
+*.sh    text eol=lf
+
+# Files contents of which must not change
+*.png   binary
+
+# Mark Gradle wrapper as a binary
+gradle/wrapper/gradle-wrapper.jar binary


### PR DESCRIPTION
This should make the repo friendlier to check out under various operating systems.

I additionally ran `git add --renormalize .`, which didn't add any changes to files after normalization.