### PR TITLE
fix: update permissions to write pull-requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
 
       # Check out current repository


### PR DESCRIPTION
Actually, when releasing a new version, the `release.yml` fails to create a pull request with error:
```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

We can add the `write` permissions into Github Actions to enable it.