### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,8 @@ jobs:
         id: properties
         shell: bash
         run: |
+          chmod +x ./gradlew
+          
           PROPERTIES="$(./gradlew properties --console=plain -q)"
           VERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"
           NAME="$(echo "$PROPERTIES" | grep "^pluginName:" | cut -f2- -d ' ')"


### PR DESCRIPTION
This PR aims to fix a bug in Export Properties, the error log is as follows.

> 2022-09-09T05:43:48.3461950Z ##[group]Run PROPERTIES="$(./gradlew properties --console=plain -q)"
2022-09-09T05:43:48.3462449Z [36;1mPROPERTIES="$(./gradlew properties --console=plain -q)"[0m
2022-09-09T05:43:48.3462857Z [36;1mVERSION="$(echo "$PROPERTIES" | grep "^version:" | cut -f2- -d ' ')"[0m
2022-09-09T05:43:48.3463250Z [36;1mNAME="$(echo "$PROPERTIES" | grep "^pluginName:" | cut -f2- -d ' ')"[0m
2022-09-09T05:43:48.3463664Z [36;1mCHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"[0m
2022-09-09T05:43:48.3464050Z [36;1mCHANGELOG="${CHANGELOG//'%'/'%25'}"[0m
2022-09-09T05:43:48.3464357Z [36;1mCHANGELOG="${CHANGELOG//$'\n'/'%0A'}"[0m
2022-09-09T05:43:48.3464680Z [36;1mCHANGELOG="${CHANGELOG//$'\r'/'%0D'}"[0m
2022-09-09T05:43:48.3464922Z [36;1m[0m
2022-09-09T05:43:48.3465193Z [36;1mecho "::set-output name=version::$VERSION"[0m
2022-09-09T05:43:48.3465511Z [36;1mecho "::set-output name=name::$NAME"[0m
2022-09-09T05:43:48.3465821Z [36;1mecho "::set-output name=changelog::$CHANGELOG"[0m
2022-09-09T05:43:48.3466243Z [36;1mecho "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"[0m
2022-09-09T05:43:48.3466564Z [36;1m[0m
2022-09-09T05:43:48.3466901Z [36;1m./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier[0m
2022-09-09T05:43:48.3532696Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
2022-09-09T05:43:48.3533174Z env:
2022-09-09T05:43:48.3533440Z   JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/11.0.16-8/x64
2022-09-09T05:43:48.3533759Z   JAVA_HOME_11_X64: /opt/hostedtoolcache/Java_Zulu_jdk/11.0.16-8/x64
2022-09-09T05:43:48.3534024Z ##[endgroup]
2022-09-09T05:43:48.3620087Z /home/runner/work/_temp/39358f9a-db64-42dd-bd7c-bf06981fa3cf.sh: line 1: ./gradlew: Permission denied
2022-09-09T05:43:48.3636251Z ##[error]Process completed with exit code 126.
