### PR TITLE
Fix pluginVersion for unreleased version

### DIFF
--- a/.github/template-cleanup/gradle.properties
+++ b/.github/template-cleanup/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = %GROUP%
 pluginName = %NAME%
 pluginRepositoryUrl = https://github.com/%REPOSITORY%
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.1
+pluginVersion = Unreleased
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213


### PR DESCRIPTION
Changelog v2.0.0 requires contains pluginVersion as version in CHANGELOG.md.

I got error:
```
1 problem was found storing the configuration cache.
- Task `:patchPluginXml` of type `org.jetbrains.intellij.tasks.PatchPluginXmlTask`: value 'map(java.lang.String provider(?) check-type())' failed to unpack provider
(snip)
> org.jetbrains.changelog.exceptions.MissingVersionException: Version is missing: any
```
