### PR TITLE
Clearer comment for .github/workflows/release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 # GitHub Actions Workflow created for handling the release process based on the draft release prepared
-# with the Build workflow. Running the publishPlugin task requires the PUBLISH_TOKEN secret provided.
+# with the Build workflow. Running the publishPlugin task requires all of the following secrets to be be provided:
+# PUBLISH_TOKEN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, CERTIFICATE_CHAIN
+# See https://plugins.jetbrains.com/docs/intellij/plugin-signing.html for more information
 
 name: Release
 on:


### PR DESCRIPTION
Hey 👋 Amazing work with this template!
Got a little bit stuck during publishing, cause it seems that only `PUBLISH_TOKEN` is required.