### PR TITLE
Remove Gradle Kotlin DSL Lazy Property Assignment

### DIFF
--- a/.github/template-cleanup/gradle.properties
+++ b/.github/template-cleanup/gradle.properties
@@ -29,6 +29,3 @@ org.gradle.configuration-cache = true
 
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
-
-# Enable Gradle Kotlin DSL Lazy Property Assignment -> https://docs.gradle.org/current/userguide/kotlin_dsl.html#kotdsl:assignment
-systemProp.org.gradle.unsafe.kotlin.assignment = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- Remove Gradle Kotlin DSL Lazy Property Assignment because it's default now
+
 ## [1.11.3] - 2023-12-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.11.3] - 2023-12-01
+
 ### Changed
 
 - Upgrade Gradle Wrapper to `8.5`
@@ -646,7 +648,8 @@
 - GitHub Actions to automate testing and deployment
 - Kotlin support
 
-[Unreleased]: https://github.com/JetBrains/intellij-platform-plugin-template/compare/v1.11.2...HEAD
+[Unreleased]: https://github.com/JetBrains/intellij-platform-plugin-template/compare/v1.11.3...HEAD
+[1.11.3]: https://github.com/JetBrains/intellij-platform-plugin-template/compare/v1.11.2...v1.11.3
 [1.11.2]: https://github.com/JetBrains/intellij-platform-plugin-template/compare/v1.11.1...v1.11.2
 [1.11.1]: https://github.com/JetBrains/intellij-platform-plugin-template/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/JetBrains/intellij-platform-plugin-template/compare/v1.10.0...v1.11.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,3 @@ org.gradle.configuration-cache = true
 
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
-
-# Enable Gradle Kotlin DSL Lazy Property Assignment -> https://docs.gradle.org/current/userguide/kotlin_dsl.html#kotdsl:assignment
-systemProp.org.gradle.unsafe.kotlin.assignment = true


### PR DESCRIPTION
because it's default now