### PR TITLE
Plugin publication: fix the channel selector

### DIFF
--- a/.github/template-cleanup/settings.gradle.kts
+++ b/.github/template-cleanup/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 rootProject.name = "%NAME%"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,13 +239,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
-      # Set up Java environment for the next steps
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: zulu
-          java-version: 17
-
       # Remove old release drafts by using the curl request for the available releases with a draft flag
       - name: Remove Old Release Drafts
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Gradle - upgrade `org.gradle.toolchains.foojay-resolver-convention` to `0.8.0`
 
+### Fixed
+
+- Fixed calculation of the plugin publication channel
+
 ### Removed
 
 - GitHub Actions: Remove the `Setup Java` step from the `releaseDraft` build step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Gradle - upgrade `org.gradle.toolchains.foojay-resolver-convention` to `0.8.0`
 
+### Removed
+
+- GitHub Actions: Remove the `Setup Java` step from the `releaseDraft` build step
+
 ## [1.12.0] - 2024-02-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Gradle - upgrade `org.gradle.toolchains.foojay-resolver-convention` to `0.8.0`
+
 ## [1.12.0] - 2024-02-20
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,6 @@ tasks {
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels = properties("pluginVersion").map { listOf(it.substringAfter('-').substringBefore('.').ifEmpty { "default" }) }
+        channels = properties("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 rootProject.name = "IntelliJ Platform Plugin Template"


### PR DESCRIPTION
Before this patch, publisher was always using the channel corresponding to the first number in the plugin version for release builds. This is because by default, Kotlin's `substringAfter` will return the whole input string if it's unable to find the needle.

So, for example, `"1.2.3".substringAfter('-').substringBefore('.')` would yield `"1"`.