### PR TITLE
fix JVM toolchain download

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,5 @@
 rootProject.name = "IntelliJ Platform Plugin Template"
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}


### PR DESCRIPTION
The `build.gradle.kts` defines a JVM toolchain, but if no compatible JDK is found, no JDK is downloaded and the build fails.  
To download a JDK automatically if needed, we need the `org.gradle.toolchains.foojay-resolver-convention` plugin. Tested on Arch Linux, with JDK21 installed: after adding the foojay plugin, `./gradlew buildPlugin` no longer fails, and it downloads a compatible JDK17.