### PR TITLE
README: Update Continuous Integration section with note on setting GitHub Actions permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,10 @@ Within the default project structure, there is a `.run` directory provided conta
 Continuous integration depends on [GitHub Actions][gh:actions], a set of workflows that make it possible to automate your testing and release process.
 Thanks to such automation, you can delegate the testing and verification phases to the Continuous Integration (CI) and instead focus on development (and writing more tests).
 
+> [!NOTE]
+> To ensure the "Create Pull Request" step functions correctly in the "Publish Plugin" job, make sure to enable "Read and write permissions" for actions by navigating to `⚙️ Settings > Actions > General > Workflow permissions`.
+
+
 In the `.github/workflows` directory, you can find definitions for the following GitHub Actions workflows:
 
 - [Build](.github/workflows/build.yml)


### PR DESCRIPTION
This update improves the Continuous Integration (CI) documentation by adding a note on configuring GitHub Actions permissions. Without the specified "Read and write permissions" setting, attempts to execute the "Create Pull Request" step in the "Publish Plugin" job may fail, causing the following error:

![image](https://github.com/user-attachments/assets/4388d031-b2a7-451f-9442-530a701abfd3)

```
2024-11-04T14:54:19.0941876Z Switched to a new branch 'changelog-update-v1.4.0'
2024-11-04T14:54:19.1052147Z [changelog-update-v1.4.0 099822b] Changelog update - v1.4.0
2024-11-04T14:54:19.1053680Z  1 file changed, 42 insertions(+), 12 deletions(-)
2024-11-04T14:54:19.6046236Z To https://github.com/siropkin/kursor
2024-11-04T14:54:19.6050386Z  ! [remote rejected] changelog-update-v1.4.0 -> changelog-update-v1.4.0 (refusing to allow a GitHub App to create or update workflow `.github/workflows/build.yml` without `workflows` permission)
2024-11-04T14:54:19.6054203Z error: failed to push some refs to 'https://github.com/siropkin/kursor'
2024-11-04T14:54:19.6081564Z ##[error]Process completed with exit code 1.
```