### PR TITLE
GitHub Actions: Remove gradle/actions/wrapper-validation because validation is performed by default in gradle/actions/setup-gradle@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
-      # Validate wrapper
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
-
       # Set up Java environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
This step is no longer necessary, as setup-gradle@v4 [will now handle the same wrapper validation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation).

From the [Build action log](https://github.com/JetBrains/intellij-platform-plugin-template/actions/runs/12324116118/job/34401040534?pr=491) of this PR without wrapper-validation:
```
All Gradle Wrapper jars are valid
  ✓ Found known Gradle Wrapper JAR files:
    2db75c40782f5e8ba1fc278a5574bab070adccb2d21ca5a6e5ed840888448046 gradle/wrapper/gradle-wrapper.jar
```