### PR TITLE
chore: fix typo CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,7 +327,7 @@
 ### Added
 
 - [Kover](https://github.com/Kotlin/kotlinx-kover) integration
-- Enable [Gradle Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) in `gradle.proeprties`
+- Enable [Gradle Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html) in `gradle.properties`
 - GitHub Actions — mark the pull request created with _Publish Plugin_ workflow with `release changelog` label
 - GitHub Actions — send code coverage reports to [CodeCov](https://codecov.io)
 - Dependencies - upgrade `org.jetbrains.kotlinx.kover` to `0.6.1`


### PR DESCRIPTION
# chore: fix typo in CHANGELOG.md

## Description
This pull request fixes a minor typo in the `CHANGELOG.md` file. The word **`proeprties`** has been corrected to **`properties`**.

### Changes
- Fixed the typo: `gradle.proeprties` → `gradle.properties`.
