### PR TITLE
Dependencies - upgrade org.gradle.toolchains.foojay-resolver-convention to 0.10.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 rootProject.name = "IntelliJ Platform Plugin Template"
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
 }


### PR DESCRIPTION
https://plugins.gradle.org/plugin/org.gradle.toolchains.foojay-resolver-convention

I guess Dependabot doesn't see this? Or maybe [the ignore](https://github.com/JetBrains/intellij-platform-plugin-template/pull/402#issuecomment-1695446543) was too strong.