### PR TITLE
fix(actions): use github event release body as conditional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       # Create a pull request
       - name: Create Pull Request
-        if: ${{ steps.properties.outputs.changelog != '' }}
+        if: ${{ github.event.release.body != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
The current release.yml workflow does not create pull requests anymore because the conditional on the properties output of a previous step has been removed recently.

This PR suggests to just use `if: ${{ github.event.release.body != '' }}` like in the previous step "Patch Changelog"