### PR TITLE
Fix CHANGELOG.md comparison links that assume "v" prefix for tags

### DIFF
--- a/.github/template-cleanup/build.gradle.kts
+++ b/.github/template-cleanup/build.gradle.kts
@@ -114,6 +114,7 @@ intellijPlatform {
 changelog {
     groups.empty()
     repositoryUrl = providers.gradleProperty("pluginRepositoryUrl")
+    versionPrefix = ""
 }
 
 // Configure Gradle Kover Plugin - read more: https://kotlin.github.io/kotlinx-kover/gradle-plugin/#configuration-details

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
           RELEASE_NOTE="./build/tmp/release_note.txt"
           ./gradlew getChangelog --unreleased --no-header --quiet --console=plain --output-file=$RELEASE_NOTE
 
-          gh release create v$VERSION \
+          gh release create $VERSION \
             --draft \
             --title $VERSION \
             --notes-file $RELEASE_NOTE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@
 
 ### Added
 
-- GitHub Actions: template `build.gradle.kts` without the Changelog `sectionUrlBuilder` for tag prefix handling
+- GitHub Actions: template `build.gradle.kts` with `versionPrefix` to set default tag prefix
 
 ### Fixed
 
-- GitHub Actions - release tag version missing "v" prefix when created
-- Gradle - comparison links in CHANGELOG.md using "v" prefix for tags that don't have it
+- Add `sectionUrlBuilder` Changelog property to `build.gradle.kts` so comparison links in `CHANGELOG.md` will use correct tag prefix
 
 ## [2.4.0] - 2025-11-25
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,14 +116,15 @@ changelog {
     repositoryUrl = providers.gradleProperty("pluginRepositoryUrl")
     // Handle some of GitHub release tags missing the default "v" prefix
     sectionUrlBuilder = ChangelogSectionUrlBuilder { repositoryUrl, currentVersion, previousVersion, isUnreleased ->
+        val vVersions = listOf("2.2.0", "2.1.0", "2.0.2", "2.0.1", "2.0.0", "1.14.2", "1.14.1", "1.14.0", "1.13.0", "1.12.0", "1.11.3", "1.11.2", "1.11.1", "1.11.0", "1.10.0", "1.9.0", "1.8.0", "1.7.0", "1.6.0", "1.5.0", "1.4.0", "1.3.0", "1.2.0", "1.1.2", "1.1.1", "1.1.0", "1.0.0", "0.10.1", "0.10.0", "0.9.0", "0.8.3", "0.8.2", "0.8.1", "0.8.0", "0.7.1", "0.7.0", "0.6.1", "0.6.0", "0.5.1", "0.5.0", "0.4.0", "0.3.2", "0.3.1", "0.3.0", "0.2.0", "0.1.0", "0.0.2", "0.0.1")
         val prefix: (String?) -> String = { version -> when (version) {
-            "2.3.0" -> ""
-            "2.3.1" -> ""
-            "2.4.0" -> ""
-            else -> "v"
+            in vVersions -> "v"
+            else -> ""
         } }
+
         val previousPrefix = prefix(previousVersion)
         val currentPrefix = prefix(currentVersion)
+
         repositoryUrl + when {
             isUnreleased -> when (previousVersion) {
                 null -> "/commits"


### PR DESCRIPTION
Some of the header links in `CHANGELOG.md` don't work because the `patchChangelog` assumes that all tags have a "v" prefix by default. The "v" prefix for GitHub tags was removed from the draft release job in `.github/workflows/build.yml` a few versions ago ~~and this doesn't seem like the intended behaviour~~.

Let me know what you think :) 

-----
Edit: Sorry just read #556, ~~I'll make some changes~~ I updated the PR to match intended behaviour.