### PR TITLE
fix: handle empty releases list in draft cleanup step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,10 +240,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DRAFTS=$(gh api repos/{owner}/{repo}/releases --jq '.[] | select(.draft == true) | .id')
-          if [ -n "$DRAFTS" ]; then
-            echo "$DRAFTS" | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
-          fi
+          gh api repos/{owner}/{repo}/releases \
+            --jq '.[] | select(.draft == true) | .id' \
+            | xargs -r -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
 
       # Create a new release draft which is not publicly visible and requires manual acceptance
       - name: Create Release Draft

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,9 +240,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api repos/{owner}/{repo}/releases \
-            --jq '.[] | select(.draft == true) | .id' \
-            | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
+          DRAFTS=$(gh api repos/{owner}/{repo}/releases --jq '.[] | select(.draft == true) | .id')
+          if [ -n "$DRAFTS" ]; then
+            echo "$DRAFTS" | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
+          fi
 
       # Create a new release draft which is not publicly visible and requires manual acceptance
       - name: Create Release Draft

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [2.4.1] - 2026-03-20
 
+### Fixed
+
+- GitHub Actions: handle empty releases list in draft cleanup step using `xargs -r`
+
 ### Changed
 
 - Upgrade Gradle Wrapper to `9.4.1`


### PR DESCRIPTION
## Problem

The `releaseDraft` job in `build.yml` fails on new projects that have no releases yet:

```
gh api repos/{owner}/{repo}/releases \
  --jq '.[] | select(.draft == true) | .id' \
  | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}

unexpected end of JSON input
Error: Process completed with exit code 123.
```

When there are no releases, `gh api` returns empty JSON. The `--jq` filter produces no output, and `xargs` fails with exit code 123.

## Fix

Capture the draft IDs into a variable first, then only run the delete loop if there are drafts to delete. This preserves error propagation for real failures (network errors, auth issues) while gracefully handling the empty case.

## Reproduction

1. Create a new project from this template
2. Push to `main`
3. The `releaseDraft` job fails on the "Remove Old Release Drafts" step